### PR TITLE
Split linting and formatting CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,29 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
+  format:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: nightly
-          components: rustfmt, clippy
-    - uses: Swatinem/rust-cache@v2
+          components: rustfmt
     - name: Check formatting
       # Use nightly for formatting to enable unstable formatting styles
       # * group imports
       # * import_granularity
       run: cargo +nightly fmt -- --check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+          toolchain: stable
+          components: clippy
+    - uses: Swatinem/rust-cache@v2
     - name: Clippy
       run: |
         cargo --version


### PR DESCRIPTION
Using nightly for the linting job prevents the cache being effective as
the rust version forms part of the cache key.

Splitting the jobs in two allows the formatting job to use nightly
(where the cache is not required as third party crates are not used)
while letting the clippy job re-use a stable cache to improve build
times.
