### PR TITLE
Remove unused generic client

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -7,11 +7,6 @@ use uuid::Uuid;
 use crate::model::app_metadata::AppMetadata;
 use crate::model::metadata::Root;
 
-pub trait Client {
-    fn app_metadata(&self) -> impl Future<Output = Result<AppMetadata, ClientError>> + Send;
-    fn run_metadata(&self, id: Uuid) -> impl Future<Output = Result<Root, ClientError>> + Send;
-}
-
 pub type ClientResult<T> = Result<T, ClientError>;
 
 pub struct TiledClient {
@@ -26,12 +21,10 @@ impl TiledClient {
         let body = response.text().await?;
         serde_json::from_str(&body).map_err(|e| ClientError::InvalidResponse(e, body))
     }
-}
-impl Client for TiledClient {
-    async fn app_metadata(&self) -> ClientResult<AppMetadata> {
+    pub async fn app_metadata(&self) -> ClientResult<AppMetadata> {
         self.request::<AppMetadata>("/api/v1/").await
     }
-    async fn run_metadata(&self, id: Uuid) -> ClientResult<Root> {
+    pub async fn run_metadata(&self, id: Uuid) -> ClientResult<Root> {
         self.request::<Root>(&format!("/api/v1/metadata/{id}"))
             .await
     }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4,10 +4,9 @@ use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::Extension;
 use axum::response::{Html, IntoResponse};
 
-use crate::clients::Client;
 use crate::model::TiledQuery;
 
-pub async fn graphql_handler<T: Client + Send + Sync + 'static>(
+pub async fn graphql_handler(
     schema: Extension<Schema<TiledQuery, EmptyMutation, EmptySubscription>>,
     req: GraphQLRequest,
 ) -> GraphQLResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ async fn serve(config: GlazedConfig) -> Result<(), Box<dyn error::Error>> {
     .finish();
 
     let app = Router::new()
-        .route("/graphql", post(graphql_handler::<TiledClient>))
+        .route("/graphql", post(graphql_handler))
         .route("/graphiql", get(graphiql_handler))
         .layer(Extension(schema));
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,7 +5,7 @@ pub(crate) mod metadata;
 use async_graphql::Object;
 use uuid::Uuid;
 
-use crate::clients::{Client, ClientError, TiledClient};
+use crate::clients::{ClientError, TiledClient};
 
 pub(crate) struct TiledQuery(pub TiledClient);
 


### PR DESCRIPTION
Simplify implementation of client. This should have been removed when we removed the mock client.