### PR TITLE
Add fallback handler for unknown endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 RUN cargo build --release --target x86_64-unknown-linux-musl
 
+COPY ./static ./static
 COPY ./src ./src
 
 RUN cargo build --release --target x86_64-unknown-linux-musl

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::error;
 
 use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+use axum::http::StatusCode;
+use axum::response::Html;
 use axum::routing::{get, post};
 use axum::{Extension, Router};
 
@@ -54,6 +56,10 @@ async fn serve(config: GlazedConfig) -> Result<(), Box<dyn error::Error>> {
     let app = Router::new()
         .route("/graphql", post(graphql_handler))
         .route("/graphiql", get(graphiql_handler))
+        .fallback((
+            StatusCode::NOT_FOUND,
+            Html(include_str!("../static/404.html")),
+        ))
         .layer(Extension(schema));
 
     let listener = tokio::net::TcpListener::bind(config.bind_address).await?;

--- a/static/404.html
+++ b/static/404.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Glazed</title>
+    </head>
+    <body>
+        <h1>GraphQL interface to Tiled</h1>
+        <p>
+            Service is available at
+            <a href="/graphql">/graphql</a>.
+            Playground is available for testing at
+            <a href="/graphiql">/graphiql</a>
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
Replaces the default browser 404 page stopping the root of the service
looking the same as the server not running error state.
