### PR TITLE
Return useful error when using GET for /graphql

### DIFF
--- a/static/get_graphql_warning.html
+++ b/static/get_graphql_warning.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Glazed</title>
+    </head>
+    <body>
+        <p>Requests should be made as graphql queries</p>
+    </body>
+</html>


### PR DESCRIPTION
Graphql expects a POST request so warn when client uses GET
