### PR TITLE
Add reusable reqwest::Client to TiledClient

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,7 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
 
 async fn serve(config: GlazedConfig) -> Result<(), Box<dyn error::Error>> {
     let schema = Schema::build(
-        TiledQuery(TiledClient {
-            address: config.tiled_client.address.to_owned(),
-        }),
+        TiledQuery(TiledClient::new(config.tiled_client.address)),
         EmptyMutation,
         EmptySubscription,
     )

--- a/src/model.rs
+++ b/src/model.rs
@@ -84,7 +84,6 @@ impl TiledQuery {
 mod tests {
     use async_graphql::{EmptyMutation, EmptySubscription, Schema, value};
     use httpmock::MockServer;
-    use url::Url;
     use uuid::Uuid;
 
     use crate::TiledQuery;
@@ -92,9 +91,7 @@ mod tests {
 
     fn build_schema(url: &str) -> Schema<TiledQuery, EmptyMutation, EmptySubscription> {
         Schema::build(
-            TiledQuery(TiledClient {
-                address: Url::parse(url).unwrap(),
-            }),
+            TiledQuery(TiledClient::new(url.parse().unwrap())),
             EmptyMutation,
             EmptySubscription,
         )


### PR DESCRIPTION
Saves creating a new instance (containing its own connection pool) for
each request.

Add new factory methods to build the client from a URL without the
fields having to be public.
