### PR TITLE
Move download handler function into handlers

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -1,10 +1,7 @@
 use axum::body::Body;
-use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use serde_json::{Value, json};
-use tracing::{error, info};
-
-use crate::clients::TiledClient;
+use tracing::error;
 
 const FORWARDED_HEADERS: [&str; 4] = [
     "content-disposition",
@@ -13,16 +10,7 @@ const FORWARDED_HEADERS: [&str; 4] = [
     "last-modified",
 ];
 
-pub async fn download(
-    State(client): State<TiledClient>,
-    Path((run, stream, det, id)): Path<(String, String, String, u32)>,
-) -> (StatusCode, HeaderMap, Body) {
-    info!("Downloading {run}/{stream}/{det}/{id}");
-    let req = client.download(run, stream, det, id).await;
-    forward_download_response(req).await
-}
-
-async fn forward_download_response(
+pub async fn forward_download_response(
     response: Result<reqwest::Response, reqwest::Error>,
 ) -> (StatusCode, HeaderMap, Body) {
     match response {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2,8 +2,13 @@ use async_graphql::http::GraphiQLSource;
 use async_graphql::*;
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::Extension;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{Html, IntoResponse};
+use tracing::info;
 
+use crate::clients::TiledClient;
 use crate::model::TiledQuery;
 
 pub async fn graphql_handler(
@@ -16,4 +21,13 @@ pub async fn graphql_handler(
 
 pub async fn graphiql_handler() -> impl IntoResponse {
     Html(GraphiQLSource::build().endpoint("/graphql").finish())
+}
+
+pub async fn download_handler(
+    State(client): State<TiledClient>,
+    Path((run, stream, det, id)): Path<(String, String, String, u32)>,
+) -> (StatusCode, HeaderMap, Body) {
+    info!("Downloading {run}/{stream}/{det}/{id}");
+    let req = client.download(run, stream, det, id).await;
+    crate::download::forward_download_response(req).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use tracing::info;
 
 use crate::clients::TiledClient;
 use crate::config::GlazedConfig;
-use crate::handlers::{graphiql_handler, graphql_handler};
+use crate::handlers::{download_handler, graphiql_handler, graphql_handler};
 use crate::model::TiledQuery;
 
 #[tokio::main]
@@ -54,7 +54,7 @@ async fn serve(config: GlazedConfig) -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new()
         .route("/graphql", post(graphql_handler).get(graphql_get_warning))
         .route("/graphiql", get(graphiql_handler))
-        .route("/asset/{run}/{stream}/{det}/{id}", get(download::download))
+        .route("/asset/{run}/{stream}/{det}/{id}", get(download_handler))
         .with_state(client)
         .fallback((
             StatusCode::NOT_FOUND,


### PR DESCRIPTION
Makes more sense for it to be there and makes it easier for it to share header
handling with the graphql endpoint.
