### PR TITLE
Let CI pass when pushing to codecov fails

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -56,7 +56,7 @@ jobs:
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
       with:
         files: lcov.info
-        fail_ci_if_error: true
+        fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # Ensure that no files (most likely the Cargo.lock file) have changed


### PR DESCRIPTION
On a fork, where `secrets.CODECOV_TOKEN` may not be set, the CI should be able to run