### PR TITLE
Use --locked for pre-build step of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN rustup target add x86_64-unknown-linux-musl && \
 RUN mkdir src && echo 'fn main() {}' > src/main.rs
 COPY Cargo.toml Cargo.lock ./  
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry cargo build --release --target x86_64-unknown-linux-musl 
+RUN --mount=type=cache,target=/usr/local/cargo/registry cargo build\
+    --release\
+    --locked\
+    --target x86_64-unknown-linux-musl
 
 COPY static ./static
 COPY src ./src


### PR DESCRIPTION
Ensures that the versions of dependencies used in the final build are
the same as those cached by the previous build.
